### PR TITLE
Changelog check only against prod and when modifying Phantom src code

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -4,7 +4,6 @@ const userIsAdmin = danger.github.pr.user.login === "sidiousvic";
 const baseBranch = danger.github.pr.base.ref;
 const PRAgainstProd = baseBranch === "production";
 const PRAgainstDev = baseBranch === "dev";
-// const hasModifiedPhantom = danger.git.modified_files.join("").includes("src/");
 const includesChangelog = danger.git.modified_files.includes("CHANGELOG.md");
 
 // MESSAGES
@@ -20,8 +19,8 @@ let message = "";
 if (PRAgainstProd && !userIsAdmin) message += YouOpenedAPRAgainstProd;
 else if (PRAgainstDev) message += YouOpenedAPRAgainstDev;
 
-// CHANGELOG WAS NOT INCLUDED
-if (!includesChangelog) {
+// CHANGELOG WAS NOT INCLUDED WHEN UPDATING PROD
+if (PRAgainstProd && !includesChangelog) {
   message += YouForgotAChangelogFile;
 }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -4,6 +4,7 @@ const userIsAdmin = danger.github.pr.user.login === "sidiousvic";
 const baseBranch = danger.github.pr.base.ref;
 const PRAgainstProd = baseBranch === "production";
 const PRAgainstDev = baseBranch === "dev";
+const hasModifiedPhantom = danger.git.modified_files.join("").includes("src/");
 const includesChangelog = danger.git.modified_files.includes("CHANGELOG.md");
 
 // MESSAGES
@@ -19,8 +20,8 @@ let message = "";
 if (PRAgainstProd && !userIsAdmin) message += YouOpenedAPRAgainstProd;
 else if (PRAgainstDev) message += YouOpenedAPRAgainstDev;
 
-// CHANGELOG WAS NOT INCLUDED WHEN UPDATING PROD
-if (PRAgainstProd && !includesChangelog) {
+// CHANGELOG WAS NOT INCLUDED WHEN UPDATING PROD AFTER CHANGING SOURCE CODE
+if (PRAgainstProd && hasModifiedPhantom && !includesChangelog) {
   message += YouForgotAChangelogFile;
 }
 


### PR DESCRIPTION
Kermitoid will only check for a CHANGELOG when a PR is against `production` and `src/` files are changed.

For PRs against `dev`, the plan is to institute a contributor-friendly PR template.