### PR TITLE
Fix: changed tsconfig option to compile to es2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2019",
     "module": "esnext",
     "lib": ["dom", "es2017"],
     "skipLibCheck": true,


### PR DESCRIPTION
### Thank you for contributing to [Phantom](https://github.com/sidiousvic/phantom)!

👻 Please review our [contribution guidelines](../CONTRIBUTING.md).

### Description

<sup>_What changes did you make?_ **⚠️ DO NOT LEAVE EMPTY** </sup>
Changed the JS target version TypeScript was compiling to.
For some reason compiling to esnext/es2020 breaks the examples. Setting it to es2019 made it work.